### PR TITLE
Disabling jinja cache to fix weird intermittent 500 errors

### DIFF
--- a/marthas_dashboard.wsgi
+++ b/marthas_dashboard.wsgi
@@ -5,3 +5,4 @@ dir_path = os.path.dirname(os.path.realpath(__file__))
 sys.path.insert(0, dir_path)
 
 from marthas_dashboard import app as application
+application.jinja_env.cache = None


### PR DESCRIPTION
Fixes the errors that we were occasionally getting on the dashboard, which were caused by a bad version of the templates caching.